### PR TITLE
Trigger Source Nets through Internal Source Queues

### DIFF
--- a/SMX_CHANGELOG.md
+++ b/SMX_CHANGELOG.md
@@ -1,3 +1,11 @@
+# `v1.2.0` (pending)
+
+### New Features
+- Allow to add source queues with `smx_net_source_add()`.
+- Allow to read from source queues with `smx_net_source_read()`.
+- Allow to write to source queues with `smx_net_source_write()`.
+
+-------------------
 # `v1.1.2` (latest)
 
 ### Improvements

--- a/SMX_CHANGELOG.md
+++ b/SMX_CHANGELOG.md
@@ -4,6 +4,7 @@
 - Allow to add source queues with `smx_net_source_add()`.
 - Allow to read from source queues with `smx_net_source_read()`.
 - Allow to write to source queues with `smx_net_source_write()`.
+- Allow to register source callback functions with `smx_net_source_register_callback()`
 
 -------------------
 # `v1.1.2` (latest)

--- a/config.mk
+++ b/config.mk
@@ -7,8 +7,8 @@
 
 # The version number of the box library ($(VMAJ).$(VMIN).$(VREV))
 VMAJ = 1
-VMIN = 1
-VREV = 2
+VMIN = 2
+VREV = 0
 VDEB = 1
 
 # the RTS library

--- a/include/smxch.h
+++ b/include/smxch.h
@@ -390,6 +390,7 @@ void smx_channel_destroy_end( smx_channel_end_t* end );
  *              went wrong.
  */
 smx_msg_t* smx_channel_read( void* h, smx_channel_t* ch );
+smx_msg_t* smx_channel_read_rts( void* h, smx_channel_t* ch );
 
 /**
  * @brief Returns the number of available messages in channel
@@ -488,6 +489,7 @@ void smx_channel_terminate_source( smx_channel_t* ch );
  * @return      0 on success, -1 otherwise
  */
 int smx_channel_write( void* h, smx_channel_t* ch, smx_msg_t* msg );
+int smx_channel_write_rts( void* h, smx_channel_t* ch, smx_msg_t* msg );
 
 /**
  * Create a collector structure and initialize it.

--- a/include/smxnet.h
+++ b/include/smxnet.h
@@ -379,11 +379,14 @@ int smx_net_run( pthread_t* ths, int idx, void* box_impl( void* arg ), void* h )
  * @param len
  *  The length of the queue to initialise.
  * @param timeout
- *  On optional read timeout.
+ *  An optional read timeout.
+ * @param idx
+ *  The index of the source new channel.
  * @return
  *  0 on success, -1 on failure.
  */
-int smx_net_source_add( smx_net_t* net, int len, struct timespec* timeout );
+int smx_net_source_add( smx_net_t* net, int len, struct timespec* timeout,
+        int* idx );
 
 /**
  * Read from the source queue of the net.

--- a/include/smxnet.h
+++ b/include/smxnet.h
@@ -372,6 +372,45 @@ void smx_net_report_rate_warning( smx_net_t* h );
 int smx_net_run( pthread_t* ths, int idx, void* box_impl( void* arg ), void* h );
 
 /**
+ * Add a source queue to the net.
+ *
+ * @param net
+ *  A pointer to the net instance.
+ * @param len
+ *  The length of the queue to initialise.
+ * @param timeout
+ *  On optional read timeout.
+ * @return
+ *  0 on success, -1 on failure.
+ */
+int smx_net_source_add( smx_net_t* net, int len, struct timespec* timeout );
+
+/**
+ * Read from the source queue of the net.
+ *
+ * @param net
+ *  A pointer to the net instance.
+ * @param idx
+ *  The index of the source port.
+ * @return
+ *  A pointer to a message structure ::smx_msg_s or NULL if something went
+ *  wrong.
+ */
+smx_msg_t* smx_net_source_read( smx_net_t* net, int idx );
+
+/**
+ * Write to the source queue of the net.
+ *
+ * @param net
+ *  A pointer to the net instance.
+ * @param idx
+ *  The index of the source port.
+ * @return
+ *  0 on success, -1 on failure.
+ */
+int smx_net_source_write( smx_net_t* net, int idx, smx_msg_t* msg );
+
+/**
  * @brief the start routine of a thread associated to a box
  *
  * @param h                 pointer to the net handler

--- a/include/smxnet.h
+++ b/include/smxnet.h
@@ -402,6 +402,22 @@ int smx_net_source_add( smx_net_t* net, int len, struct timespec* timeout,
 smx_msg_t* smx_net_source_read( smx_net_t* net, int idx );
 
 /**
+ * Register a callback function to handle blocking calls to external libraries.
+ *
+ * @param net
+ *  A pointer to the net instance.
+ * @param idx
+ *  The index of the source port.
+ * @param callback
+ *  The callback function to register. The callback function has no return
+ *  value and takes the net pointer as argument.
+ * @return
+ *  0 on success, -1 on failure.
+ */
+int smx_net_source_register_callback( smx_net_t* net, int idx,
+        smx_source_callback_t callback );
+
+/**
  * Write to the source queue of the net.
  *
  * @param net

--- a/include/smxtypes.h
+++ b/include/smxtypes.h
@@ -81,6 +81,7 @@ typedef struct smx_net_sig_s smx_net_sig_t;           /**< ::smx_net_sig_s */
 typedef struct smx_config_data_map_s smx_config_data_map_t;
 /** ::smx_msg_tsmem_data_maps_s */
 typedef struct smx_config_data_maps_s smx_config_data_maps_t;
+/** The source callback function signature */
 typedef void (*smx_source_callback_t)( smx_net_t* net );
 /**
  * The error state of a channel end
@@ -398,11 +399,16 @@ struct smx_net_s
 };
 
 /**
- *
+ * The source channel structure
  */
 struct smx_net_source_s
 {
+    /**
+     * The callback function which is executed before each main loop run of a
+     * net.
+     */
     smx_source_callback_t callback;
+    /** The source channel. */
     smx_channel_t* port;
 };
 
@@ -425,7 +431,7 @@ struct smx_net_sig_s
     } out;                          /**< output channels */
     struct {
         int count;                  /**< the number of connected source ports */
-        /** an array of channel pointers */
+        /** an array of source channel structures */
         smx_net_source_t items[SMX_MAX_SOURCE_CHS];
     } source;                       /**< internal input channel for sources */
 };

--- a/include/smxtypes.h
+++ b/include/smxtypes.h
@@ -42,6 +42,11 @@
 #define SMX_MAX_CHS 10000
 
 /**
+ * The number of maximal allowed source channels in one streamix net.
+ */
+#define SMX_MAX_SOURCE_CHS 10
+
+/**
  * The streamix channel error type. Refer to the error enumeration definition
  * for more details #smx_channel_err_e.
  */
@@ -407,6 +412,11 @@ struct smx_net_sig_s
         int len;                    /**< the number of output ports */
         smx_channel_t** ports;      /**< an array of channel pointers */
     } out;                          /**< output channels */
+    struct {
+        int count;                  /**< the number of connected source ports */
+        /** an array of channel pointers */
+        smx_channel_t* ports[SMX_MAX_SOURCE_CHS];
+    } source;                       /**< internal input channel for sources */
 };
 
 /**

--- a/include/smxtypes.h
+++ b/include/smxtypes.h
@@ -81,7 +81,7 @@ typedef struct smx_net_sig_s smx_net_sig_t;           /**< ::smx_net_sig_s */
 typedef struct smx_config_data_map_s smx_config_data_map_t;
 /** ::smx_msg_tsmem_data_maps_s */
 typedef struct smx_config_data_maps_s smx_config_data_maps_t;
-
+typedef void (*smx_source_callback_t)( smx_net_t* net );
 /**
  * The error state of a channel end
  */
@@ -398,6 +398,17 @@ struct smx_net_s
 };
 
 /**
+ *
+ */
+struct smx_net_source_s
+{
+    smx_source_callback_t callback;
+    smx_channel_t* port;
+};
+
+typedef struct smx_net_source_s smx_net_source_t;
+
+/**
  * The signature of a net
  */
 struct smx_net_sig_s
@@ -415,7 +426,7 @@ struct smx_net_sig_s
     struct {
         int count;                  /**< the number of connected source ports */
         /** an array of channel pointers */
-        smx_channel_t* ports[SMX_MAX_SOURCE_CHS];
+        smx_net_source_t items[SMX_MAX_SOURCE_CHS];
     } source;                       /**< internal input channel for sources */
 };
 

--- a/src/smxch.c
+++ b/src/smxch.c
@@ -266,6 +266,12 @@ void smx_channel_destroy_end( smx_channel_end_t* end )
 /*****************************************************************************/
 smx_msg_t* smx_channel_read( void* h, smx_channel_t* ch )
 {
+    return smx_channel_read_rts( h, ch );
+}
+
+/*****************************************************************************/
+smx_msg_t* smx_channel_read_rts( void* h, smx_channel_t* ch )
+{
     smx_msg_t* msg = NULL;
     if( ch == NULL )
     {
@@ -280,6 +286,12 @@ smx_msg_t* smx_channel_read( void* h, smx_channel_t* ch )
 
     if( ch->source->err != SMX_CHANNEL_ERR_NONE )
     {
+        return NULL;
+    }
+
+    if( ch->source->state != SMX_CHANNEL_READY )
+    {
+        // await timed out
         return NULL;
     }
 
@@ -480,6 +492,12 @@ void smx_channel_terminate_source( smx_channel_t* ch )
 
 /*****************************************************************************/
 int smx_channel_write( void* h, smx_channel_t* ch, smx_msg_t* msg )
+{
+    return smx_channel_write_rts( h, ch, msg );
+}
+
+/*****************************************************************************/
+int smx_channel_write_rts( void* h, smx_channel_t* ch, smx_msg_t* msg )
 {
     int rc = 0;
     int nsec_sum;

--- a/src/smxnet.c
+++ b/src/smxnet.c
@@ -479,7 +479,8 @@ int smx_net_run( pthread_t* ths, int idx, void* box_impl( void* arg ), void* h )
 }
 
 /*****************************************************************************/
-int smx_net_source_add( smx_net_t* net, int len, struct timespec* timeout )
+int smx_net_source_add( smx_net_t* net, int len, struct timespec* timeout,
+        int* idx )
 {
     int cnt = 0;
     int rc;
@@ -501,6 +502,7 @@ int smx_net_source_add( smx_net_t* net, int len, struct timespec* timeout )
         }
     }
 
+    *idx = net->sig->source.count;
     net->sig->source.ports[net->sig->source.count] = ch;
     net->sig->source.count++;
 

--- a/src/smxnet.c
+++ b/src/smxnet.c
@@ -109,6 +109,7 @@ smx_net_t* smx_net_create( unsigned int id, const char* name,
     net->sig->out.ports = NULL;
     net->sig->out.count = 0;
     net->sig->out.len = 0;
+    net->sig->source.count = 0;
 
     net->rts = rts;
     net->state = NULL;
@@ -146,12 +147,18 @@ smx_net_t* smx_net_create( unsigned int id, const char* name,
 /*****************************************************************************/
 void smx_net_destroy( smx_net_t* h )
 {
+    int i;
+
     if( h != NULL )
     {
         if( h->name != NULL )
+        {
             free( h->name );
+        }
         if( h->impl != NULL )
+        {
             free( h->impl );
+        }
         if( h->static_conf != NULL )
         {
             bson_destroy( h->static_conf );
@@ -162,10 +169,18 @@ void smx_net_destroy( smx_net_t* h )
         }
         if( h->sig != NULL )
         {
+            for( i = 0; i < h->sig->source.count; i++ )
+            {
+                smx_channel_destroy( h->sig->source.ports[i] );
+            }
             if( h->sig->in.ports != NULL )
+            {
                 free( h->sig->in.ports );
+            }
             if( h->sig->out.ports != NULL )
+            {
                 free( h->sig->out.ports );
+            }
             free( h->sig );
         }
         free( h );
@@ -464,6 +479,57 @@ int smx_net_run( pthread_t* ths, int idx, void* box_impl( void* arg ), void* h )
 }
 
 /*****************************************************************************/
+int smx_net_source_add( smx_net_t* net, int len, struct timespec* timeout )
+{
+    int cnt = 0;
+    int rc;
+    smx_channel_t* ch = smx_channel_create( &cnt, len, SMX_D_FIFO, 999,
+            "source", "ch_source");
+
+    if( ch == NULL )
+    {
+        return -1;
+    }
+
+    if( timeout != NULL )
+    {
+        rc = smx_set_read_timeout( ch, timeout->tv_sec,
+                timeout->tv_nsec );
+        if( rc < 0 )
+        {
+            return -1;
+        }
+    }
+
+    net->sig->source.ports[net->sig->source.count] = ch;
+    net->sig->source.count++;
+
+    return 0;
+}
+
+/*****************************************************************************/
+smx_msg_t* smx_net_source_read( smx_net_t* net, int idx )
+{
+    if( idx < 0 || idx >= net->sig->source.count )
+    {
+        return NULL;
+    }
+
+    return smx_channel_read( net, net->sig->source.ports[idx] );
+}
+
+/*****************************************************************************/
+int smx_net_source_write( smx_net_t* net, int idx, smx_msg_t* msg )
+{
+    if( idx < 0 || idx >= net->sig->source.count )
+    {
+        return -1;
+    }
+
+    return smx_channel_write( net, net->sig->source.ports[idx], msg );
+}
+
+/*****************************************************************************/
 void* smx_net_start_routine( smx_net_t* h, int impl( void*, void* ),
         int init( void*, void** ), void cleanup( void*, void* ) )
 {
@@ -643,30 +709,28 @@ void* smx_net_start_routine_with_shared_state( smx_net_t* h,
         // only block for normal nets
         if( h->attr == NULL )
         {
+            for( int i = 0; i < h->sig->source.count; i++)
+            {
+                rc = smx_channel_await( h, h->sig->source.ports[i] );
+                if( rc != SMX_CHANNEL_ERR_OPEN && rc != SMX_CHANNEL_ERR_TIMEOUT
+                        && rc < 0 )
+                {
+                    goto smx_terminate_net;
+                }
+            }
             for( int i = 0; i < h->sig->in.count; i++)
             {
                 rc = smx_channel_await( h, h->sig->in.ports[i] );
-                if( rc == SMX_CHANNEL_ERR_OPEN || rc == SMX_CHANNEL_ERR_TIMEOUT )
+                if( rc != SMX_CHANNEL_ERR_OPEN && rc != SMX_CHANNEL_ERR_TIMEOUT
+                        && rc < 0 )
                 {
-                    rc = SMX_CHANNEL_ERR_NONE;
-                    continue;
-                }
-                if( rc < 0 )
-                {
-                    break;
+                    goto smx_terminate_net;
                 }
             }
         }
-        if( rc < 0 )
-        {
-            state = SMX_NET_END;
-        }
-        else
-        {
-            smx_profiler_log_net( h, SMX_PROFILER_ACTION_NET_START_IMPL );
-            state = impl( h, h->state );
-            smx_profiler_log_net( h, SMX_PROFILER_ACTION_NET_END_IMPL );
-        }
+        smx_profiler_log_net( h, SMX_PROFILER_ACTION_NET_START_IMPL );
+        state = impl( h, h->state );
+        smx_profiler_log_net( h, SMX_PROFILER_ACTION_NET_END_IMPL );
         state = smx_net_update_state( h, state );
         smx_profiler_log_net( h, SMX_PROFILER_ACTION_NET_END );
     }
@@ -677,9 +741,9 @@ smx_terminate_net:
     SMX_LOG_NET( h, notice, "cleanup net" );
     cleanup( h, h->state );
     elapsed_wall = ( h->end_wall.tv_sec - h->start_wall.tv_sec );
-    elapsed_wall += ( h->end_wall.tv_nsec - h->start_wall.tv_nsec) / 1000000000.0;
+    elapsed_wall += ( h->end_wall.tv_nsec - h->start_wall.tv_nsec ) / 1000000000.0;
     SMX_LOG_NET( h, notice, "terminate net (loop count: %ld, loop rate: %d, wall time: %f)",
-            h->count, (int)(h->count/elapsed_wall), elapsed_wall );
+            h->count, ( int )( h->count / elapsed_wall ), elapsed_wall );
     return NULL;
 }
 


### PR DESCRIPTION
In order to streamline the trigger handling of source boxes internal source queues can no be crated, read from, and written to:

- Add source queues with `smx_net_source_add()`.
- Read from source queues with `smx_net_source_read()`.
- Write to source queues with `smx_net_source_write()`.

Construction and clean-up is handled by the RTS.